### PR TITLE
Docker Desktopユーザー向けの注釈を追加した

### DIFF
--- a/docs/1_tools.md
+++ b/docs/1_tools.md
@@ -31,6 +31,11 @@ Docker や Kubernetes などのコンテナ環境は、主に Linux 環境を想
 - macOS: [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/) をインストール
 - Linux: [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) をインストール
 
+ハンズオンの過程で Docker コンテナからホストのネットワークにアクセスする必要が生じる場合があります。
+Docker Desktop 4.34.0 以上をお使いの方は、
+[Docker のドキュメント](https://docs.docker.com/engine/network/drivers/host/#docker-desktop)
+に従って host networking を有効化しておくことをおすすめします。
+
 検証時: Docker Engine - Community 26.1.2
 
 ## kubectl

--- a/docs/4_controllers.md
+++ b/docs/4_controllers.md
@@ -378,7 +378,7 @@ Pod の名前は、Deployment のランダムな suffix の管理と違い、`{S
     - もしくは redis-cli が手元にある場合は、単に `redis-cli -h localhost`
 
 > [!NOTE]
-> Docker Desktop を使用した環境では `localhost` の代わりに `host.docker.internal` を指定してください。
+> Docker Desktop 4.34.0 未満を使用している場合は `localhost` の代わりに `host.docker.internal` を指定してください。
 
 次のような動作が確認できれば成功です。
 

--- a/docs/4_controllers.md
+++ b/docs/4_controllers.md
@@ -377,6 +377,9 @@ Pod の名前は、Deployment のランダムな suffix の管理と違い、`{S
 - `docker run -it --rm --network host redis redis-cli -h localhost`
     - もしくは redis-cli が手元にある場合は、単に `redis-cli -h localhost`
 
+> [!NOTE]
+> Docker Desktop を使用した環境では `localhost` の代わりに `host.docker.internal` を指定してください。
+
 次のような動作が確認できれば成功です。
 
 ```plaintext

--- a/docs/7_volumes.md
+++ b/docs/7_volumes.md
@@ -171,7 +171,7 @@ spec:
 - `mysql -h127.0.0.1 -uroot -ppassword`
 
 > [!NOTE]
-> Docker Desktop を使用した環境では `127.0.0.1` の代わりに `host.docker.internal` を指定してください。
+> Docker Desktop 4.34.0 未満を使用している場合は `127.0.0.1` の代わりに `host.docker.internal` を指定してください。
 
 ```plaintext
 # mysql -h127.0.0.1 -uroot -ppassword

--- a/docs/7_volumes.md
+++ b/docs/7_volumes.md
@@ -170,6 +170,9 @@ spec:
 
 - `mysql -h127.0.0.1 -uroot -ppassword`
 
+> [!NOTE]
+> Docker Desktop を使用した環境では `127.0.0.1` の代わりに `host.docker.internal` を指定してください。
+
 ```plaintext
 # mysql -h127.0.0.1 -uroot -ppassword
 mysql: [Warning] Using a password on the command line interface can be insecure.


### PR DESCRIPTION
## 変更の内容

- 準備の章に4.34.0以上の環境に向けた案内を追加した．
- コンテナからホスト側のアプリへアクセスする場面に Docker Desktop 4.34.0 未満の環境に向けた注釈を追加した．
  - 4章: 初めてのコントローラ
    - redis-cli で redis へアクセスするとき
  - 7章: Volumes
    - MySQL Client でデータベースに接続するとき

## 変更の理由

Docker Desktop を使用した環境では，`--network host` を付けたとしても，`localhost` がコンテナ自身を参照してしまうようです．`localhost` の代わりに `host.docker.internal` を指定することで，コンテナ内からホスト側へリクエストを送信できました．

[Explore networking features on Docker Desktop](https://docs.docker.com/desktop/features/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host)

今後，同じ問題に直面した方の助けになればと思い，注釈を追加しました．